### PR TITLE
Fix maven build error in PAVCalibratedPredictiveModelBuilderBuilder

### DIFF
--- a/src/main/java/quickdt/calibratedPredictiveModel/PAVCalibratedPredictiveModelBuilderBuilder.java
+++ b/src/main/java/quickdt/calibratedPredictiveModel/PAVCalibratedPredictiveModelBuilderBuilder.java
@@ -23,7 +23,7 @@ public class PAVCalibratedPredictiveModelBuilderBuilder implements PredictiveMod
     }
 
 
-    public PAVCalibratedPredictiveModelBuilderBuilder(PredictiveModelBuilderBuilder<? extends PredictiveModel, PredictiveModelBuilder<? extends PredictiveModel>> predictiveModelBuilderBuilder) {
+    public PAVCalibratedPredictiveModelBuilderBuilder(PredictiveModelBuilderBuilder<? extends PredictiveModel, ? extends PredictiveModelBuilder<? extends PredictiveModel>> predictiveModelBuilderBuilder) {
         this.predictiveModelBuilderBuilder = predictiveModelBuilderBuilder;
     }
 


### PR DESCRIPTION
_Error_
quickdt/src/main/java/quickdt/calibratedPredictiveModel/PAVCalibratedPredictiveModelBuilderBuilder.java:[26,133] type parameter quickdt.PredictiveModelBuilder<? extends quickdt.PredictiveModel> is not within its bound
