### PR TITLE
make mockito a test dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.9.5</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
i dont think the intention was for any project that uses quickml to suddenly have a compile and runtime dependency on mockito?